### PR TITLE
Fix ocaml warnings

### DIFF
--- a/src/convert_relations.ml
+++ b/src/convert_relations.ml
@@ -1814,7 +1814,9 @@ let transform_rule
   (* Stores the dependencies on other indreln translations *)
   let requests = ref [] in
   (* The variables that appears in the rule's [forall] part *)
+  (* TODO: remove this or actually use it somewhere
   let vars = Nfmap.domain (Nfmap.from_list rule.rule_vars) in
+   *)
   let avoid = ref Nset.empty in
   (* Constructs the patterns for input mode. Used at the end. *)
   let (patterns, initeqs) =

--- a/src/def_trans.ml
+++ b/src/def_trans.ml
@@ -119,7 +119,7 @@ let remove_opens _ env (((d,_),_,_) as def) =
         Some (env, [comment_def def])
     | _ -> None
 
-let remove_import_include _ env (((d,s),l,lenv) as def) =
+let remove_import_include _ env (((d,s),l,lenv)) =
   let aux mk_f = function
     | Ast.OI_open sk -> None
     | Ast.OI_import sk ->
@@ -475,13 +475,13 @@ let class_constraint_to_parameter targ : def_macro = fun mod_path env ((d,s),l,l
               begin
                 let c_d = c_env_lookup l_unk c_env c in
                 let new_pats = pats_from_constraints (filter_constraints c_d.const_class) in
-  	        let (c', t', c_env') = 
+	        let (c', t', c_env') =
                   match Targetmap.apply_target c_d.const_no_class targ with
 		    | Some c' -> 
                         let c_d' = c_env_lookup l_unk c_env c' in
                         (c', c_d'.const_type, c_env)
-  		    | None -> 
-                      begin            
+		    | None ->
+                      begin
                         let t' = Types.multi_fun (List.map (fun x -> x.typ) new_pats) c_d.const_type in
 
                         (* for debug 

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -54,7 +54,7 @@ let r = Ulib.Text.of_latin1
 
 let parse_int lexbuf i =
   try (int_of_string i, i)
-  with Failure "int_of_string" ->
+  with Failure _ ->
     raise (Reporting_basic.Fatal_error (Reporting_basic.Err_syntax (
            Lexing.lexeme_start_p lexbuf,
            "couldn't parse integer "^i)))

--- a/src/module_dependencies.ml
+++ b/src/module_dependencies.ml
@@ -74,12 +74,12 @@ let module_dependency_is_cyclic md =
     extension ".lem" *)
 let filename_to_modname filename = 
   let filename_base = Filename.basename (Filename.chop_extension filename) in
-  String.capitalize filename_base
+  String.capitalize_ascii filename_base
 
 (** convert a module name to a file name by uncapitalising it and adding the
     extension ".lem" *)
-let modname_to_filename modname = 
-  String.uncapitalize (modname ^ ".lem")
+let modname_to_filename modname =
+  String.uncapitalize_ascii (modname ^ ".lem")
 
 (** [search_module_file mod_name] searches for the file a module [mod_name].
     This can be done arbitrarily clever, e.g. by searching a list of given
@@ -110,7 +110,7 @@ let load_module_file (filename, loc, needs_output, is_user_import) =
   let missing_deps = begin
     let needed_modules = Ast_util.get_imported_modules ast in
     let needed_modules_top = List.map (fun (n, l) -> ((Path.get_toplevel_name n), l)) needed_modules (* only top_level modules can be loaded by files *) in
-    let needed_module_strings = List.map (fun (n, l) -> (String.capitalize (Name.to_string n), l)) needed_modules_top in
+    let needed_module_strings = List.map (fun (n, l) -> (String.capitalize_ascii (Name.to_string n), l)) needed_modules_top in
     DepSetExtra.from_list needed_module_strings
   end in
   { 

--- a/src/name.ml
+++ b/src/name.ml
@@ -204,13 +204,13 @@ let starts_with_lower_letter (_, x) =
 
 let uncapitalize ((_, y) as x) = 
   if (starts_with_upper_letter x) then
-    let c = Ulib.UChar.of_char (Char.lowercase (Ulib.UChar.char_of (Ulib.UTF8.get y 0))) in
+    let c = Ulib.UChar.of_char (Char.lowercase_ascii (Ulib.UChar.char_of (Ulib.UTF8.get y 0))) in
     Some (from_rope (Ulib.Text.set (to_rope x) 0 c))
   else None
 
 let capitalize ((_, y) as x) =
   if (starts_with_lower_letter x) then
-    let c = Ulib.UChar.of_char (Char.uppercase (Ulib.UChar.char_of (Ulib.UTF8.get y 0))) in
+    let c = Ulib.UChar.of_char (Char.uppercase_ascii (Ulib.UChar.char_of (Ulib.UTF8.get y 0))) in
     Some (from_rope (Ulib.Text.set (to_rope x) 0 c))
   else None
 

--- a/src/patterns.ml
+++ b/src/patterns.ml
@@ -84,7 +84,7 @@ let check_number_patterns_aux (p : pat) : bool =
      raise (Reporting_basic.err_type p.locn "number pattern not of type nat or natural") in
   true
 
-let check_number_patterns env p = (for_all_subpat check_number_patterns_aux p; ())
+let check_number_patterns env p = (ignore(for_all_subpat check_number_patterns_aux p); ())
 
 
 
@@ -2135,8 +2135,10 @@ let my_list_compile_step
     | _ -> raise Pat_Matrix_Compile_Fun_Failed in
 
   (* Auxiliary vars/pvars/wildcards *)
-  let new_list_wc_pat = matrix_compile_mk_pwild list_ty in
-  let new_elem_wc_pat = matrix_compile_mk_pwild elem_ty in
+  (* TODO: remove this or actually use it somewhere
+   let new_list_wc_pat = matrix_compile_mk_pwild list_ty in *)
+  (* TODO: remove this or actually use it somewhere
+  let new_elem_wc_pat = matrix_compile_mk_pwild elem_ty in *)
   let new_list_var_name = gen None list_ty in
   let new_elem_var_name = gen None elem_ty in
 
@@ -2180,11 +2182,15 @@ let my_list_compile_step
       match_compile_unreachable "my_list_compile_step wrong no of args to rest_pat_const" in
 
   (* Reconstruction function *)
+  (* TODO: remove this or actually use it somewhere
   let nil_pats =
     List.filter (is_list_pat (Some 0)) pL in
+  *)
+  (* TODO: remove this or actually use it somewhere
   let cons_pats =
     List.filter (fun p ->
         is_cons_pat p || (is_list_pat None p && not (is_list_pat (Some 0) p))) pL in
+   *)
   let top_fun i eL =
     match eL with
     | e_nil :: e_cons :: e_wilds ->
@@ -2336,12 +2342,15 @@ let my_compile_step (env : env) (mk_failure : env -> Ast.l -> Types.t -> exp)
   let restr_pat (id, _) pL =
     C.mk_pconst l id (List.map mk_opt_paren_pat pL) (Some p_ty) in
 
+  (* TODO: remove this or actually use it somewhere
   let case_fun_else p ee =
-    Some ([], ee) in
-  let dest_in_else e = [] in
-  let restr_pat_else _ = matrix_compile_mk_pwild p_ty in
-
-  let nall = List.length all_args in
+     Some ([], ee) in *)
+  (* TODO: remove this or actually use it somewhere
+  let dest_in_else e = [] in *)
+  (* TODO: remove this or actually use it somewhere
+  let restr_pat_else _ = matrix_compile_mk_pwild p_ty in *)
+  (* TODO: remove this or actually use it somewhere
+  let nall = List.length all_args in *)
 
   Some
     (top_fun,

--- a/src/precedence.ml
+++ b/src/precedence.ml
@@ -75,7 +75,7 @@ type t = P_prefix
        | P_special
 
 let t_to_int = function
-  | P_special _ -> -1
+  | P_special -> -1
   | P_prefix -> 0
   | P_infix i -> i
   | P_infix_left i -> i

--- a/src/process_file.ml
+++ b/src/process_file.ml
@@ -179,7 +179,7 @@ let output1 env (out_dir : string option) (targ : Target.target) avoid m =
       | Target.Target_no_ident (Target.Target_lem) -> 
           begin
             let r = B.lem_defs m.typed_ast in
-            let module_name_lower = String.uncapitalize module_name in
+            let module_name_lower = String.uncapitalize_ascii module_name in
             let (o, ext_o) = open_output_with_check dir (module_name_lower ^ "-processed.lem") in
               Printf.fprintf o "%s" (Ulib.Text.to_string r);
               close_output_with_check ext_o
@@ -238,7 +238,7 @@ let output1 env (out_dir : string option) (targ : Target.target) avoid m =
       | Target.Target_no_ident(Target.Target_ocaml) -> 
           begin
             let (r_main, r_extra_opt) = B.ocaml_defs m.typed_ast in
-            let module_name_lower = String.uncapitalize module_name in
+            let module_name_lower = String.uncapitalize_ascii module_name in
             let _ = if (!only_auxiliary) then () else begin
               let (o, ext_o) = open_output_with_check dir (module_name_lower ^ ".ml") in
               Printf.fprintf o "(*%s*)\n" (generated_line m.filename);

--- a/src/reporting_basic.ml
+++ b/src/reporting_basic.ml
@@ -70,9 +70,9 @@ let read_from_file_pos2 p1 p2 =
   let ic = open_in p1.Lexing.pos_fname in
   let _ = seek_in ic s in
   let l = (e - s) in
-  let buf = String.create l in
+  let buf = Bytes.create l in
   let _ = input ic buf 0 l in
-  let _ = match multi with None -> () | Some sk -> String.fill buf 0 sk ' ' in
+  let _ = match multi with None -> () | Some sk -> Bytes.fill buf 0 sk ' ' in
   let _ = close_in ic in
   (buf, not (multi = None))
 

--- a/src/typecheck.ml
+++ b/src/typecheck.ml
@@ -908,7 +908,7 @@ module Make_checker(T : sig
           C.add_constraint (External_constants.class_label_to_path "class_numeral") t_ret;
           if is_pattern then C.add_constraint (External_constants.class_label_to_path "class_ord") t_ret else ();
           if is_pattern then C.add_constraint (External_constants.class_label_to_path "class_num_minus") t_ret else ();
-          let i_int = try int_of_string i with Failure "int_of_string" ->
+          let i_int = try int_of_string i with Failure _ ->
             raise (Reporting_basic.Fatal_error (Reporting_basic.Err_syntax_locn (l, "couldn't parse integer "^i))) in
           annot (L_num(sk,i_int, Some i)) t_ret 
       | Ast.L_string(sk,i) ->
@@ -3166,7 +3166,7 @@ let rec check_def (backend_targets : Targetset.t) (mod_path : Name.t list)
           let sub = begin
             let var_subst = Seplist.fold_left (fun (RName(_,name,r_ref,_,typschm, _,_,_,_)) subst ->
               begin
-    	        let name = Name.strip_lskip name in
+	        let name = Name.strip_lskip name in
                 let name_d = c_env_lookup l newctxt.ctxt_c_env r_ref in
                 let id = { id_path = Id_some (Ident.mk_ident None [] name); 
                            id_locn = l; descr = r_ref; 
@@ -3406,8 +3406,8 @@ let rec check_def (backend_targets : Targetset.t) (mod_path : Name.t list)
 
                    (* check that [n] has the right type / check whether it is in the set of methods *)
                    let _ = try
-  		       let (_, _, n_class_ty) = List.find (fun (_, n', _) -> Name.compare n n' = 0) class_methods in
-                       if Types.check_equal ctxt.all_tdefs n_class_ty n_d.const_type then 
+                       let (_, _, n_class_ty) = List.find (fun (_, n', _) -> Name.compare n n' = 0) class_methods in
+                       if Types.check_equal ctxt.all_tdefs n_class_ty n_d.const_type then
                           (* type matches, everything OK *) ()
                        else begin
                          let t_should = Types.t_to_string n_class_ty in
@@ -3445,7 +3445,7 @@ let rec check_def (backend_targets : Targetset.t) (mod_path : Name.t list)
 
 
           (* add a dictionary constant *)
-          let dict_name = Name.from_string (String.uncapitalize (Name.to_string instance_name) ^ "_dict") in
+          let dict_name = Name.from_string (String.uncapitalize_ascii (Name.to_string instance_name) ^ "_dict") in
 
           let dict_type = class_descr_get_dict_type p_d src_t.typ in
 

--- a/src/types.ml
+++ b/src/types.ml
@@ -1600,10 +1600,12 @@ module Constraint (T : Global_defs) : Constraint = struct
          end
        | _ -> assert false (*Normal so should not be reached*)
     in
+    (* TODO: remove completely, or actually use it somewhere
     let rec walk_constraints = function
     | [ ] -> [ ]
     | c :: constraints -> range_with c (add_vars all_vars (range_of_n c)) :: (walk_constraints  constraints)
-    in 
+    in
+    *)
     Array.of_list(List.map (fun r -> ref (Some r)) constraints (* (walk_constraints constraints) *))
     
   let is_inconsistent = function

--- a/src/ulib/batUTF8.ml
+++ b/src/ulib/batUTF8.ml
@@ -203,10 +203,8 @@ let validate s =
   main 0
 
 let of_ascii s =
-  for i = 0 to String.length s - 1 do
-    if Char.code s.[i] >= 0x80 then raise Malformed_code;
-  done;
-  String.copy s
+  String.iter (fun c -> if Char.code c >= 0x80 then raise Malformed_code) s;
+  s
 
 let of_latin1 s = init (String.length s) (fun i -> BatUChar.of_char s.[i])
 

--- a/src/util.ml
+++ b/src/util.ml
@@ -290,7 +290,7 @@ let uncapitalize_prefix =
     begin
       let c = Bytes.get x p in
       if is_uppercase c then
-        let c' = Char.lowercase c in
+        let c' = Char.lowercase_ascii c in
         let _ = Bytes.set x p c' in
         true
       else


### PR DESCRIPTION
Hi,

I fixed most of the warnings when compiling with `4.06.0`. Except those like: `this pattern-matching is not exhaustive`, as doing something better than: `_ -> assert false` would take more time (but I'll try to have a look at it later).

My editor also removed a lot of trailing white-spaces, once #7 is merged, I'll rebase this one so we'll only see the fix for the warnings, easing the review of the PR.