### PR TITLE
Use Zarith in Nat_num instead of ocaml-num

### DIFF
--- a/library/run-ocaml-tests.sh
+++ b/library/run-ocaml-tests.sh
@@ -11,10 +11,10 @@ for file in *Auxiliary.ml
 do
   echo $file
   file_nat=${file%.ml}.native
-  ocamlfind ocamlc -package zarith -linkpkg -o ${file_nat} -I ocaml-lib/_build_zarith nums.cma extract.cma ${file}
-done 
+  ocamlfind ocamlc -package zarith -linkpkg -o ${file_nat} -I ocaml-lib/_build_zarith extract.cma ${file}
+done
 
-for file in *.native 
+for file in *.native
 do
   file_name=`basename $file`
   file_name=${file_name%Auxiliary.native}
@@ -24,6 +24,3 @@ do
   echo "***************************************************\n"
   ./$file
 done
-
-
-

--- a/ocaml-lib/nat_num.ml
+++ b/ocaml-lib/nat_num.ml
@@ -1,5 +1,7 @@
+open Big_int_impl
+
 type nat = int
-type natural = Big_int.big_int
+type natural = BI.big_int
 
 let nat_monus x y =
   let d = x - y in
@@ -9,35 +11,34 @@ let nat_monus x y =
       d
 
 let natural_monus x y =
-    (if Big_int.le_big_int x y then
-      Big_int.zero_big_int
+    (if BI.le_big_int x y then
+      BI.zero_big_int
     else
-      (Big_int.sub_big_int x y))
+      (BI.sub_big_int x y))
 
 let nat_pred x = nat_monus x 1
-let natural_pred x = natural_monus x Big_int.unit_big_int
+let natural_pred x = natural_monus x BI.unit_big_int
 
-let int_mod i n = 
+let int_mod i n =
   let r = i mod n in
   if (r < 0) then r + n else r
 
-let int_div i n = 
+let int_div i n =
   let r = i / n in
   if (i mod n < 0) then r - 1 else r
 
-let int32_mod i n = 
+let int32_mod i n =
   let r = Int32.rem i n in
   if (r < Int32.zero) then Int32.add r n else r
 
-let int32_div i n = 
+let int32_div i n =
   let r = Int32.div i n in
   if (Int32.rem i n < Int32.zero) then Int32.pred r else r
 
-let int64_mod i n = 
+let int64_mod i n =
   let r = Int64.rem i n in
   if (r < Int64.zero) then Int64.add r n else r
 
-let int64_div i n = 
+let int64_div i n =
   let r = Int64.div i n in
   if (Int64.rem i n < Int64.zero) then Int64.pred r else r
-

--- a/ocaml-lib/nat_num.ml
+++ b/ocaml-lib/nat_num.ml
@@ -1,7 +1,4 @@
-open Big_int_impl
-
 type nat = int
-type natural = BI.big_int
 
 let nat_monus x y =
   let d = x - y in
@@ -10,14 +7,7 @@ let nat_monus x y =
     else
       d
 
-let natural_monus x y =
-    (if BI.le_big_int x y then
-      BI.zero_big_int
-    else
-      (BI.sub_big_int x y))
-
 let nat_pred x = nat_monus x 1
-let natural_pred x = natural_monus x BI.unit_big_int
 
 let int_mod i n =
   let r = i mod n in

--- a/ocaml-lib/nat_num.mli
+++ b/ocaml-lib/nat_num.mli
@@ -1,10 +1,4 @@
-open Big_int_impl
-
 type nat = int
-type natural = BI.big_int
-
-val natural_monus : natural -> natural -> natural
-val natural_pred : natural -> natural
 
 val nat_pred  : nat -> nat
 val nat_monus : nat -> nat -> nat

--- a/ocaml-lib/nat_num.mli
+++ b/ocaml-lib/nat_num.mli
@@ -1,5 +1,7 @@
+open Big_int_impl
+
 type nat = int
-type natural = Big_int.big_int
+type natural = BI.big_int
 
 val natural_monus : natural -> natural -> natural
 val natural_pred : natural -> natural


### PR DESCRIPTION
This fixes the compilation on OCaml 4.06.

I've no idea why `nat_num.ml{i,}` were using directly `Big_int` over our `Big_int_impl` wrappers. There's a chance it always picked the ocaml-num implementation.

Also `run-ocaml-tests.sh` was requiring `nums.cma` - no idea why.

All the tests pass with this patch.

There's some noise because of trailing whitespace chars, but w/e.