### PR TITLE
Ignore HOL-generated files in hol-lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,14 @@ src/main.native
 src/version.ml
 examples/ppcmem-model/generated/*
 coq-lib/lem_*.v
-hol-lib/lem_*.sml
+hol-lib/lem*.sml
+hol-lib/lem*.sig
+hol-lib/lem*.ui
+hol-lib/lem*.uo
+hol-lib/lem*.dat
+hol-lib/lemheap
+hol-lib/.hollogs
+hol-lib/.HOLMK
 html-lib/*.html
 isabelle-lib/Lem_*.thy
 library/ocaml-build-dir*


### PR DESCRIPTION
If you actually build the theories in `hol-lib`, these files will be created and should also be ignored by git.