### PR TITLE
Fix some definitions to make coq-libs compile again

### DIFF
--- a/coq-lib/coqharness.v
+++ b/coq-lib/coqharness.v
@@ -561,13 +561,13 @@ Definition char_equal
   (c d: ascii): bool :=
     match c, d with
       | (Ascii b1 b2 b3 b4 b5 b6 b7 b8), (Ascii b1' b2' b3' b4' b5' b6' b7' b8') =>
-          andb (eqb b1 b1')
-          (andb (eqb b2 b2')
-          (andb (eqb b3 b3')
-          (andb (eqb b4 b4')
-          (andb (eqb b5 b5')
-          (andb (eqb b6 b6')
-          (andb (eqb b7 b7') (eqb b8 b8')))))))
+          andb (Bool.eqb b1 b1')
+          (andb (Bool.eqb b2 b2')
+          (andb (Bool.eqb b3 b3')
+          (andb (Bool.eqb b4 b4')
+          (andb (Bool.eqb b5 b5')
+          (andb (Bool.eqb b6 b6')
+          (andb (Bool.eqb b7 b7') (Bool.eqb b8 b8')))))))
     end.
 
 Fixpoint string_equal

--- a/library/bool.lem
+++ b/library/bool.lem
@@ -111,7 +111,7 @@ end
 
 declare hol      target_rep function (<->) = infix `<=>`
 declare isabelle target_rep function (<->) = infix `\<longleftrightarrow>`
-declare coq      target_rep function (<->) = `eqb`
+declare coq      target_rep function (<->) = `Bool.eqb`
 declare ocaml    target_rep function (<->) = infix `=`
 declare html     target_rep function (<->) = infix `&harr;`
 declare tex      target_rep function (<->) = infix `$\longleftrightarrow$`

--- a/library/num.lem
+++ b/library/num.lem
@@ -12,7 +12,7 @@ declare {isabelle;ocaml;hol;coq} rename module = lem_num
 open import Bool Basic_classes
 open import {isabelle} `HOL-Word.Word` `Complex_Main`
 open import {hol} `integerTheory` `intReduce` `wordsTheory` `wordsLib` `ratTheory` `realTheory` `intrealTheory` `transcTheory`
-open import {coq} `Coq.Numbers.BinNums` `Coq.ZArith.BinInt` `Coq.ZArith.Zpower` `Coq.ZArith.Zdiv` `Coq.ZArith.Zmax` `Coq.Numbers.Natural.Peano.NPeano` `Coq.QArith.Qabs` `Coq.QArith.Qminmax` `Coq.QArith.Qround` `Coq.Reals.ROrderedType` `Coq.Reals.Rbase` `Coq.Reals.Rfunctions`
+open import {coq} `Coq.Numbers.BinNums` `Coq.ZArith.BinInt` `Coq.ZArith.Zpower` `Coq.ZArith.Zdiv` `Coq.ZArith.Zmax` `Coq.Reals.Rsqrt_def` `Coq.Numbers.Natural.Peano.NPeano` `Coq.QArith.Qabs` `Coq.QArith.Qminmax` `Coq.QArith.Qround` `Coq.Reals.ROrderedType` `Coq.Reals.Rbase` `Coq.Reals.Rfunctions`
 
 (* ========================================================================== *)
 (* Numerals                                                                   *)
@@ -1743,6 +1743,7 @@ declare coq      target_rep function realFloor = `Rdown`
 val integerSqrt : integer -> integer
 let integerSqrt i = realFloor (realSqrt (realFromInteger i))
 declare ocaml    target_rep function integerSqrt = `Nat_big_num.sqrt`
+declare coq      target_rep function integerSqrt = `Z.sqrt`
 
 
 (* ========================================================================== *)


### PR DESCRIPTION
This commit fixes the errors occuring when running `make coq-libs`.