### PR TITLE
ocaml-lib: build with -g so backtraces have locations

### DIFF
--- a/ocaml-lib/_tags
+++ b/ocaml-lib/_tags
@@ -1,1 +1,2 @@
+true: debug
 <_build_zarith> or <_build_num> : not_hygienic


### PR DESCRIPTION
The ocamlbuild path (the default, USE_OCAMLBUILD=true) compiled the runtime library without -g, so exceptions raised from lem code (e.g. Not_found from Pmap.find) record no backtrace frames. In a -g program this silently leaves the previously-recorded backtrace in the global buffer, producing misleading stack traces pointing at unrelated code. Add the `debug` tag so the installed .cmx/.cmxa carry debug info, matching no_ocamlbuild.mk which already passes -g.